### PR TITLE
Tie ratings to versions

### DIFF
--- a/app/Entities/Models/Track.php
+++ b/app/Entities/Models/Track.php
@@ -32,7 +32,6 @@ class Track extends AbstractModel implements Favoritable, SluggableInterface
         'name',
         'parts',
         'tuning',
-        'version',
         'dd',
         'riff_repeater',
         'difficulty_levels',
@@ -68,12 +67,38 @@ class Track extends AbstractModel implements Favoritable, SluggableInterface
      */
     public function ratings()
     {
-        return $this->hasMany(Rating::class)->whereVersion($this->version);
+        $versions = $this->latestVersions->lists('id');
+
+        return $this->hasMany(Rating::class)->whereIn('version_id', $versions);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function versions()
+    {
+        return $this->hasMany(Version::class)->latest();
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function latestVersions()
+    {
+        return $this->versions()->take(2);
     }
 
     //////////////////////////////////////////////////////////////////////
     ///////////////////////////// ATTRIBUTES /////////////////////////////
     //////////////////////////////////////////////////////////////////////
+
+    /**
+     * @return Version
+     */
+    public function getVersionAttribute()
+    {
+        return $this->versions->first();
+    }
 
     /**
      * @return string

--- a/app/Entities/Models/Track.php
+++ b/app/Entities/Models/Track.php
@@ -81,9 +81,9 @@ class Track extends AbstractModel implements Favoritable, SluggableInterface
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function latestVersions()
+    public function previousVersions()
     {
-        return $this->versions()->take(2);
+        return $this->versions()->skip(1);
     }
 
     //////////////////////////////////////////////////////////////////////

--- a/app/Entities/Models/Track.php
+++ b/app/Entities/Models/Track.php
@@ -67,9 +67,7 @@ class Track extends AbstractModel implements Favoritable, SluggableInterface
      */
     public function ratings()
     {
-        $versions = $this->latestVersions->lists('id');
-
-        return $this->hasMany(Rating::class)->whereIn('version_id', $versions);
+        return $this->hasMany(Rating::class)->where('version_id', $this->version->id);
     }
 
     /**

--- a/app/Entities/Models/Track.php
+++ b/app/Entities/Models/Track.php
@@ -68,7 +68,7 @@ class Track extends AbstractModel implements Favoritable, SluggableInterface
      */
     public function ratings()
     {
-        return $this->hasMany(Rating::class);
+        return $this->hasMany(Rating::class)->whereVersion($this->version);
     }
 
     //////////////////////////////////////////////////////////////////////

--- a/app/Entities/Models/Track.php
+++ b/app/Entities/Models/Track.php
@@ -83,7 +83,7 @@ class Track extends AbstractModel implements Favoritable, SluggableInterface
      */
     public function previousVersions()
     {
-        return $this->versions()->skip(1);
+        return $this->versions()->where('id', '!=', $this->version->id);
     }
 
     //////////////////////////////////////////////////////////////////////

--- a/app/Entities/Models/Version.php
+++ b/app/Entities/Models/Version.php
@@ -1,0 +1,33 @@
+<?php
+namespace Furnace\Entities\Models;
+
+class Version extends AbstractModel
+{
+    /**
+     * @type array
+     */
+    protected $fillable = [
+        'name',
+        'track_id',
+    ];
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////// RELATIONSHIPS ///////////////////////////
+    //////////////////////////////////////////////////////////////////////
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function track()
+    {
+        return $this->belongsTo(Track::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function ratings()
+    {
+        return $this->hasMany(Rating::class);
+    }
+}

--- a/app/Handlers/Commands/UpsertRatingCommandHandler.php
+++ b/app/Handlers/Commands/UpsertRatingCommandHandler.php
@@ -4,6 +4,7 @@ namespace Furnace\Handlers\Commands;
 use Furnace\Commands\UpsertRatingCommand;
 use Furnace\Commands\UpsertTrackCommand;
 use Furnace\Entities\Models\Rating;
+use Furnace\Entities\Models\Version;
 use Illuminate\Foundation\Bus\DispatchesCommands;
 
 class UpsertRatingCommandHandler
@@ -41,8 +42,9 @@ class UpsertRatingCommandHandler
 
         // Update rating
         $rating->fill($command->attributes->all());
-        $rating->track_id = $track->id;
-        $rating->user_id  = $command->user->id;
+        $rating->version_id = $track->version->id;
+        $rating->track_id   = $track->id;
+        $rating->user_id    = $command->user->id;
         $rating->save();
 
         return $rating;

--- a/app/Handlers/Commands/UpsertTrackCommandHandler.php
+++ b/app/Handlers/Commands/UpsertTrackCommandHandler.php
@@ -3,6 +3,7 @@ namespace Furnace\Handlers\Commands;
 
 use Furnace\Commands\UpsertTrackCommand;
 use Furnace\Entities\Models\Track;
+use Furnace\Entities\Models\Version;
 use Furnace\Services\Ignition;
 
 class UpsertTrackCommandHandler
@@ -48,6 +49,16 @@ class UpsertTrackCommandHandler
             'ignition_id' => $command->ignition,
         ]);
 
-        return $this->repository->create($attributes);
+        // Create Track
+        $version = array_pull($attributes, 'version');
+        $track   = $this->repository->create($attributes);
+
+        // Create related version
+        Version::firstOrCreate([
+            'name'     => $version,
+            'track_id' => $track->id,
+        ]);
+
+        return $track;
     }
 }

--- a/app/Http/Composers/HelpComposer.php
+++ b/app/Http/Composers/HelpComposer.php
@@ -1,7 +1,6 @@
 <?php
 namespace Furnace\Http\Composers;
 
-use Config;
 use Furnace\Services\ScoreComputer;
 use Illuminate\View\View;
 
@@ -36,7 +35,7 @@ class HelpComposer
             'presilence'        => ['Pre-silence', '1 or 0'],
             'playable'          => ['Playable', '1 or 0'],
             'dd'                => ['Dynamic difficulty', '1 or 0'],
-            'rr'                => ['Riff Repeater', '1 or 0'],
+            'riff_repeater'     => ['Riff Repeater', '1 or 0'],
             'has_pc'            => ['PC version available', '1 or 0'],
             'difficulty_levels' => ['Difficulty levels', 'Ratio to 5'],
             'platforms'         => ['Platforms', 'Ratio to 4, grants extra points'],
@@ -51,7 +50,7 @@ class HelpComposer
         }
 
         $criterias = array_sort($criterias, function ($criteria) {
-           return $criteria['weight'] * -1;
+            return $criteria['weight'] * -1;
         });
 
         $view->criterias = $criterias;

--- a/app/Http/Controllers/TracksController.php
+++ b/app/Http/Controllers/TracksController.php
@@ -34,7 +34,7 @@ class TracksController extends AbstractController
      */
     public function index()
     {
-        $tracks = Track::with('tracker', 'ratings', 'artist')->get();
+        $tracks = Track::with('tracker', 'ratings', 'artist', 'versions')->get();
         $tracks = $tracks->sortByDesc('score');
 
         return View::make('tracks/index', [

--- a/app/Http/Controllers/TracksController.php
+++ b/app/Http/Controllers/TracksController.php
@@ -34,7 +34,7 @@ class TracksController extends AbstractController
      */
     public function index()
     {
-        $tracks = Track::with('tracker', 'ratings')->get();
+        $tracks = Track::with('tracker', 'ratings', 'artist')->get();
         $tracks = $tracks->sortByDesc('score');
 
         return View::make('tracks/index', [

--- a/app/Services/ScoreComputer.php
+++ b/app/Services/ScoreComputer.php
@@ -70,13 +70,18 @@ class ScoreComputer
      */
     public function forTrack(Track $track, $save = true)
     {
-        // Update track's score
-        $scores = [
-            $this->computeTrackScore($track, $track->previousVersions->first()->ratings) * 0.25,
-            $this->computeTrackScore($track, $track->version->ratings) * 0.75,
-        ];
+        // Compute track's score from its versions
+        $score = $this->computeTrackScore($track, $track->version->ratings);
+        if ($track->previousVersions->count()) {
+            $scores = [
+                $this->computeTrackScore($track, $track->previousVersions->first()->ratings) * 0.25,
+                $score * 0.75,
+            ];
 
-        $score        = array_sum($scores) / count($scores);
+            $score = array_sum($scores) / count($scores);
+        }
+
+        // Assign score and save
         $track->score = $score;
         if ($save) {
             $track->save();

--- a/app/Services/ScoreComputer.php
+++ b/app/Services/ScoreComputer.php
@@ -13,6 +13,11 @@ class ScoreComputer
     protected $weights;
 
     /**
+     * @type bool
+     */
+    protected $persists = true;
+
+    /**
      * The standard number of difficulty levels.
      */
     const STANDARD_DIFFICULTY_LEVELS = 5;
@@ -37,6 +42,10 @@ class ScoreComputer
         $this->weights = $weights;
     }
 
+    //////////////////////////////////////////////////////////////////////
+    ////////////////////////////// OPTIONS ///////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+
     /**
      * @return array
      */
@@ -54,36 +63,67 @@ class ScoreComputer
     }
 
     /**
+     * @return boolean
+     */
+    public function isPersists()
+    {
+        return $this->persists;
+    }
+
+    /**
+     * @param boolean $persists
+     */
+    public function setPersists($persists)
+    {
+        $this->persists = $persists;
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    /////////////////////////////// SCORES ///////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+
+    /**
      * @param Tracker $tracker
+     *
+     * @return float
      */
     public function forBlacksmith(Tracker $tracker)
     {
-        $tracker->score = $this->computeBlacksmithScore($tracker);
-        $tracker->save();
+        $score          = $this->computeBlacksmithScore($tracker);
+        $tracker->score = $score;
+
+        if ($this->persists) {
+            $tracker->save();
+        }
+
+        return $score;
     }
 
     /**
      * @param Track $track
-     * @param bool  $save
      *
-     * @return int
+     * @return float
      */
-    public function forTrack(Track $track, $save = true)
+    public function forTrack(Track $track)
     {
+        if (!$track->version) {
+            return 0;
+        }
+
         // Compute track's score from its versions
         $score = $this->computeTrackScore($track, $track->version->ratings);
         if ($track->previousVersions->count()) {
-            $scores = [
-                $this->computeTrackScore($track, $track->previousVersions->first()->ratings) * 0.25,
-                $score * 0.75,
-            ];
-
-            $score = array_sum($scores) / count($scores);
+            $previousScore = $this->computeTrackScore($track, $track->previousVersions->first()->ratings);
+            $score         = ($previousScore * 0.25 + $score * 0.75) / 2;
         }
+
+        // Round up and ceil
+        $score = round($score, 1);
+        $score = min($score, static::RATING_SCALE);
 
         // Assign score and save
         $track->score = $score;
-        if ($save) {
+        if ($this->persists) {
             $track->save();
         }
 
@@ -123,12 +163,7 @@ class ScoreComputer
             'difficulty_levels' => min(1, round($track->difficulty_levels / static::STANDARD_DIFFICULTY_LEVELS)),
         ]);
 
-        // Round up and ceil
-        $rating = array_sum($components);
-        $rating = round($rating, 1);
-        $rating = min($rating, static::RATING_SCALE);
-
-        return $rating;
+        return array_sum($components);
     }
 
     /**
@@ -138,7 +173,7 @@ class ScoreComputer
      */
     protected function computeBlacksmithScore(Tracker $tracker)
     {
-        $ratings = $tracker->tracks()->lists('score');
+        $ratings = $tracker->tracks->lists('score');
         if (!$ratings) {
             return 0;
         }

--- a/app/Services/ScoreComputer.php
+++ b/app/Services/ScoreComputer.php
@@ -117,7 +117,7 @@ class ScoreComputer
             'presilence'        => $ratings->average('presilence'),
             'playable'          => $ratings->average('playable'),
             'dd'                => $track->dd,
-            'rr'                => $track->riff_repeater,
+            'riff_repeater'     => $track->riff_repeater,
             'has_pc'            => $track->platforms['pc'],
             'platforms'         => count($track->platforms) / 4,
             'difficulty_levels' => min(1, round($track->difficulty_levels / static::STANDARD_DIFFICULTY_LEVELS)),

--- a/app/Services/Search/Transformers/TrackTransformer.php
+++ b/app/Services/Search/Transformers/TrackTransformer.php
@@ -20,7 +20,7 @@ class TrackTransformer extends TransformerAbstract
             'slug'              => $track->slug,
             'parts'             => $track->parts,
             'tuning'            => $track->tuning,
-            'version'           => $track->version,
+            'version'           => $track->version ? $track->version->name : null,
             'dd'                => (bool) $track->dd,
             'riff_repeater'     => (bool) $track->riff_repeater,
             'difficulty_levels' => (int) $track->difficulty_levels,

--- a/config/furnace.php
+++ b/config/furnace.php
@@ -27,7 +27,7 @@ return [
         'tab'               => 1,
         'normalized_volume' => 1,
         'presilence'        => 1,
-        'playable'         => 1,
+        'playable'          => 1,
         'dd'                => 1,
         'riff_repeater'     => 1,
         'difficulty_levels' => 1,

--- a/config/furnace.php
+++ b/config/furnace.php
@@ -29,7 +29,7 @@ return [
         'presilence'        => 1,
         'playable'         => 1,
         'dd'                => 1,
-        'rr'                => 1,
+        'riff_repeater'     => 1,
         'difficulty_levels' => 1,
         'has_pc'            => 1,
         'platforms'         => 1,

--- a/database/factories/Track.php
+++ b/database/factories/Track.php
@@ -11,7 +11,6 @@ Facade::define(Track::class, [
     'parts'             => 'lead',
     'platforms'         => 'pc,mac',
     'tuning'            => 'estandard',
-    'version'           => '1.0',
     'dd'                => 'boolean',
     'riff_repeater'     => 'boolean',
     'difficulty_levels' => 'randomNumber|1',

--- a/database/factories/Version.php
+++ b/database/factories/Version.php
@@ -1,0 +1,11 @@
+<?php
+
+use Furnace\Entities\Models\Track;
+use Furnace\Entities\Models\Tracker;
+use Furnace\Entities\Models\Version;
+use League\FactoryMuffin\Facade;
+
+Facade::define(Version::class, [
+    'name'     => 'word',
+    'track_id' => 'factory|'.Track::class,
+]);

--- a/database/migrations/2015_04_16_214533_create_tracks_table.php
+++ b/database/migrations/2015_04_16_214533_create_tracks_table.php
@@ -17,7 +17,6 @@ class CreateTracksTable extends Migration
             $table->string('slug')->nullable();
             $table->string('parts');
             $table->string('tuning');
-            $table->string('version');
             $table->boolean('dd')->default(false);
             $table->boolean('riff_repeater')->default(false);
             $table->integer('difficulty_levels');

--- a/database/migrations/2015_04_16_235655_create_versions_table.php
+++ b/database/migrations/2015_04_16_235655_create_versions_table.php
@@ -1,0 +1,33 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class CreateVersionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('versions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->integer('track_id')->unsigned()->index();
+            $table->timestamps();
+
+            $table->foreign('track_id')->references('id')->on('tracks')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('versions');
+    }
+}

--- a/database/migrations/2015_04_17_001007_create_ratings_table.php
+++ b/database/migrations/2015_04_17_001007_create_ratings_table.php
@@ -33,12 +33,13 @@ class CreateRatingsTable extends Migration
 
             $table->float('total')->default(0);
 
-            $table->string('version')->nullable();
+            $table->integer('version_id')->unsigned()->index();
             $table->integer('track_id')->unsigned()->index();
             $table->integer('user_id')->unsigned()->index();
             $table->enum('platform', Config::get('furnace.platforms'))->default('pc');
             $table->timestamps();
 
+            $table->foreign('version_id')->references('id')->on('versions')->onDelete('cascade');
             $table->foreign('track_id')->references('id')->on('tracks')->onDelete('cascade');
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });

--- a/database/migrations/2015_04_17_001007_create_ratings_table.php
+++ b/database/migrations/2015_04_17_001007_create_ratings_table.php
@@ -33,6 +33,7 @@ class CreateRatingsTable extends Migration
 
             $table->float('total')->default(0);
 
+            $table->string('version')->nullable();
             $table->integer('track_id')->unsigned()->index();
             $table->integer('user_id')->unsigned()->index();
             $table->enum('platform', Config::get('furnace.platforms'))->default('pc');

--- a/database/seeds/TracksTableSeeder.php
+++ b/database/seeds/TracksTableSeeder.php
@@ -38,7 +38,7 @@ class TracksTableSeeder extends Seeder
                 'techniques'        => array_get($row, 'techniques', true),
                 'tab'               => array_get($row, 'tab'),
                 'difficulty'        => array_get($row, 'difficulty', 1),
-                'version_id'        => $track->versions->last()->id,
+                'version_id'        => $track->version->id,
                 'track_id'          => $track->id,
                 'user_id'           => 1,
             ]);

--- a/database/seeds/TracksTableSeeder.php
+++ b/database/seeds/TracksTableSeeder.php
@@ -3,6 +3,7 @@
 use Furnace\Commands\UpsertTrackCommand;
 use Furnace\Entities\Models\Rating;
 use Furnace\Entities\Models\Track;
+use Furnace\Entities\Models\Version;
 use Illuminate\Database\Seeder;
 use Illuminate\Foundation\Bus\DispatchesCommands;
 use League\Csv\Reader;
@@ -28,6 +29,7 @@ class TracksTableSeeder extends Seeder
                 'ignition' => $row['ignition_id'],
             ]);
 
+            unset($track->versions);
             Rating::create([
                 'presilence'        => array_get($row, 'presilence'),
                 'normalized_volume' => array_get($row, 'normalized_volume'),

--- a/database/seeds/TracksTableSeeder.php
+++ b/database/seeds/TracksTableSeeder.php
@@ -33,6 +33,7 @@ class TracksTableSeeder extends Seeder
                 'techniques'        => array_get($row, 'techniques', true),
                 'tab'               => array_get($row, 'tab'),
                 'difficulty'        => array_get($row, 'difficulty', 1),
+                'version'           => $track->version,
                 'track_id'          => $track->id,
                 'user_id'           => 1,
             ]);

--- a/database/seeds/TracksTableSeeder.php
+++ b/database/seeds/TracksTableSeeder.php
@@ -1,13 +1,17 @@
 <?php
 
+use Furnace\Commands\UpsertTrackCommand;
 use Furnace\Entities\Models\Rating;
 use Furnace\Entities\Models\Track;
 use Illuminate\Database\Seeder;
+use Illuminate\Foundation\Bus\DispatchesCommands;
 use League\Csv\Reader;
 use Symfony\Component\Console\Helper\ProgressBar;
 
 class TracksTableSeeder extends Seeder
 {
+    use DispatchesCommands;
+
     public function run()
     {
         $rows     = $this->getTracks();
@@ -20,8 +24,9 @@ class TracksTableSeeder extends Seeder
                 continue;
             }
 
-            $track = $this->container->make('ignition')->complete($row);
-            $track = Track::firstOrCreate($track);
+            $track = $this->dispatchFromArray(UpsertTrackCommand::class, [
+                'ignition' => $row['ignition_id'],
+            ]);
 
             Rating::create([
                 'presilence'        => array_get($row, 'presilence'),
@@ -33,7 +38,7 @@ class TracksTableSeeder extends Seeder
                 'techniques'        => array_get($row, 'techniques', true),
                 'tab'               => array_get($row, 'tab'),
                 'difficulty'        => array_get($row, 'difficulty', 1),
-                'version'           => $track->version,
+                'version_id'        => $track->versions->last()->id,
                 'track_id'          => $track->id,
                 'user_id'           => 1,
             ]);

--- a/resources/views/tracks/index.twig
+++ b/resources/views/tracks/index.twig
@@ -55,7 +55,7 @@
 			<td class="text-center">{{ boolean(track.ratings.average('playable')) }}</td>
 			<td class="text-center">{{ boolean(track.ratings.average('sync')) }}</td>
 			<td class="text-center">{{ boolean(track.ratings.average('techniques')) }}</td>
-			<td>{{ track.version }}</td>
+			<td>{{ track.version.name }}</td>
 			<td>
 				{{ progress(track.ratings.average('tone'), integer_scale) }}
 			</td>

--- a/tests/spec/FurnaceObjectBehavior.php
+++ b/tests/spec/FurnaceObjectBehavior.php
@@ -4,6 +4,7 @@ namespace spec\Furnace;
 use Furnace\Entities\Models\Track;
 use Furnace\Entities\Models\Tracker;
 use Furnace\Entities\Models\User;
+use Furnace\Entities\Models\Version;
 use Furnace\Services\Ignition;
 use League\FactoryMuffin\Facade;
 use Mockery;
@@ -19,7 +20,7 @@ class FurnaceObjectBehavior extends LaravelObjectBehavior
         $this->loadFactories();
 
         app()->bind(Ignition::class, function () {
-           return Mockery::mock(Ignition::class)->shouldReceive('complete')->andReturn([])->getMock();
+            return Mockery::mock(Ignition::class)->shouldReceive('complete')->andReturn([])->getMock();
         });
 
         User::first() ?: Facade::create(User::class);
@@ -40,6 +41,7 @@ class FurnaceObjectBehavior extends LaravelObjectBehavior
     {
         $tracker = Facade::create(Tracker::class);
         $item    = Facade::create(Track::class, ['tracker_id' => $tracker->id]);
+        $version = Version::create(['name' => '1.0', 'track_id' => $item->id]);
 
         return $item;
     }

--- a/tests/spec/Handlers/Commands/UpsertRatingCommandHandlerSpec.php
+++ b/tests/spec/Handlers/Commands/UpsertRatingCommandHandlerSpec.php
@@ -36,7 +36,7 @@ class UpsertRatingCommandHandlerSpec extends FurnaceObjectBehavior
         $command = new UpsertRatingCommand([
             'ignition_id' => $track->ignition_id,
             'audio'       => 2,
-            'comments' => 'nope',
+            'comments'    => 'nope',
         ], $user);
         $rating  = $this->handle($command);
 

--- a/tests/spec/Handlers/Commands/UpsertTrackCommandHandlerSpec.php
+++ b/tests/spec/Handlers/Commands/UpsertTrackCommandHandlerSpec.php
@@ -74,7 +74,10 @@ class UpsertTrackCommandHandlerSpec extends FurnaceObjectBehavior
             'artist_id'   => $artist->id,
         ]);
 
-        $ignition->complete(['ignition_id' => $track->ignition_id])->willReturn($track->getAttributes());
+        $ignition->complete(['ignition_id' => $track->ignition_id])->willReturn(array_merge(
+            ['version' => '1.0'],
+            $track->getAttributes()
+        ));
 
         $this->beConstructedWith($ignition, new Track);
 

--- a/tests/spec/Services/ScoreComputerSpec.php
+++ b/tests/spec/Services/ScoreComputerSpec.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace spec\Furnace\Services;
+
+use Config;
+use Furnace\Collection;
+use Furnace\Entities\Models\Rating;
+use Furnace\Entities\Models\Track;
+use Furnace\Entities\Models\Tracker;
+use Furnace\Entities\Models\Version;
+use Furnace\Services\ScoreComputer;
+use League\FactoryMuffin\Facade;
+use Prophecy\Argument;
+use spec\Furnace\FurnaceObjectBehavior;
+
+/**
+ * @mixin ScoreComputer
+ */
+class ScoreComputerSpec extends FurnaceObjectBehavior
+{
+    public function let()
+    {
+        parent::let();
+
+        $this->beConstructedWith(
+            Config::get('furnace.weights')
+        );
+
+        $this->setPersists(false);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ScoreComputer::class);
+    }
+
+    public function it_can_compute_score_of_single_version_track()
+    {
+        $version          = new Version(['name' => '1.0']);
+        $version->ratings = new Collection([
+            $this->getDummyRating(1),
+            $this->getDummyRating(3),
+        ]);
+
+        $track = Facade::instance(Track::class, [
+            'platforms'         => 'pc,mac,xbox360,ps3',
+            'riff_repeater'     => true,
+            'dd'                => true,
+            'difficulty_levels' => ScoreComputer::STANDARD_DIFFICULTY_LEVELS,
+        ]);
+
+        $track->previousVersions = new Collection();
+        $track->versions         = new Collection([$version]);
+
+        $score = $this->forTrack($track, false);
+        $score->shouldBeLike(ScoreComputer::RATING_SCALE);
+    }
+
+    public function it_can_compute_score_of_multiple_versions_track()
+    {
+        $previousVersion          = new Version(['name' => '1.0']);
+        $previousVersion->ratings = new Collection([
+            $this->getDummyRating(1),
+            $this->getDummyRating(1),
+        ]);
+
+        $version          = new Version(['name' => '2.0']);
+        $version->ratings = new Collection([
+            $this->getDummyRating(1),
+            $this->getDummyRating(3),
+        ]);
+
+        $track = Facade::instance(Track::class, [
+            'platforms'         => 'pc,mac,xbox360,ps3',
+            'riff_repeater'     => true,
+            'dd'                => true,
+            'difficulty_levels' => ScoreComputer::STANDARD_DIFFICULTY_LEVELS,
+        ]);
+
+        $track->previousVersions = new Collection([$previousVersion]);
+        $track->versions         = new Collection([$version]);
+
+        $score = $this->forTrack($track, false);
+        $score->shouldBeLike(5.9);
+    }
+
+    public function it_can_compute_blacksmith_score()
+    {
+        $blacksmith         = Facade::instance(Tracker::class);
+        $blacksmith->tracks = new Collection([
+            new Track(['score' => 5]),
+            new Track(['score' => 10]),
+        ]);
+
+        $score = $this->forBlacksmith($blacksmith);
+        $score->shouldBeLike(7.5);
+    }
+
+    /**
+     * @param integer $average
+     *
+     * @return Rating
+     */
+    protected function getDummyRating($average)
+    {
+        return new Rating([
+            'tone'              => $average,
+            'audio'             => $average,
+            'tab'               => $average,
+            'sync'              => true,
+            'techniques'        => true,
+            'normalized_volume' => true,
+            'presilence'        => true,
+            'playable'          => true
+        ]);
+    }
+}


### PR DESCRIPTION
### Changed
- Ratings are now tied to a single version of a CDLC
- Rating of a track is now 75% of its current ratings and 25% of the ratings of its previous version

---

Closes #3 